### PR TITLE
Fixed the broken configuration and alignment

### DIFF
--- a/src/Wython/dynsem.properties
+++ b/src/Wython/dynsem.properties
@@ -1,7 +1,0 @@
-source.language = Wython
-source.version = 0.1
-source.startsymbol = Program
-source.initconstructor.name = Program
-
-project.groupid = nl.tudelft
-project.artifactid = wython

--- a/src/Wython/metaborg.yaml
+++ b/src/Wython/metaborg.yaml
@@ -1,5 +1,5 @@
 ---
-id: org.metaborg.lang:Wython:0.1.0-SNAPSHOT
+id: nl.tudelft:Wython:0.1.0-SNAPSHOT
 name: Wython
 dependencies:
   compile:

--- a/src/Wython/metaborg.yaml
+++ b/src/Wython/metaborg.yaml
@@ -20,7 +20,7 @@ debug:
 language:
   sdf:
     pretty-print: Wython
-    sdf2table: c
+    sdf2table: java
     placeholder:
       prefix: "$"
     jsglr-version: layout-sensitive

--- a/src/Wython/syntax/Program.sdf3
+++ b/src/Wython/syntax/Program.sdf3
@@ -12,11 +12,7 @@ context-free start-symbols
   Start
 
 context-free syntax
-  // FIXME: This should work (according to the documentation), but doesn't force the alignment
-  // http://www.metaborg.org/en/latest/source/langdev/meta/lang/sdf3/reference.html#layout-sensitive-parsing
-  Start.FileInput = <
-    <body:CodeElement*>
-  > {layout( align 0 body )}
+  Start.FileInput = body:CodeElement* {layout (align body)}
   
 //  Start.SingleInput = SingleInput
 //  Start.EvalInput = TestList NewLine* EOF

--- a/src/Wython/trans/wython.str
+++ b/src/Wython/trans/wython.str
@@ -24,6 +24,7 @@ rules // Debugging
   editor-desugar:
     (_, _, ast, path, project-path) -> (filename, text) where
       filename := <guarantee-extension(|"desugared.aterm")> path ;
+      text     := <desugar-all> ast
 
   show-wast-ast:
     (_, _, ast, path, project-path) -> (filename, text) where


### PR DESCRIPTION
A line was incorrectly removed during a merge, making it that the builds failed. This line is now re-added, fixing most of the build issues. In addition, I removed a configuration file that caused a number of problems with my setup. Lastly I reverted the project ID to use the `nl.tudelft` domain. I know that this needs to be changed back later to get the imports working, but this change was only made partially resulting in some dependency issues.

In addition to fixing the setup I contacted @udesou on the alignment issues. There were some issues with both our project configuration and Spoofax itself. Now the alignment works, but only on the latest nightly build so please update your installation.
